### PR TITLE
add/bankAccountIcon: add Bank Account Icon

### DIFF
--- a/svg/BankAccount24.svg
+++ b/svg/BankAccount24.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
+    <title>Detalhes do recebedor - Configuracoes - fechada</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Detalhes-do-recebedor" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Detalhes-do-recebedor---Configuracoes---fechada" transform="translate(-311.000000, -667.000000)" fill="#757575" fill-rule="nonzero">
+            <g id="Icone-Copy" transform="translate(314.000000, 667.000000)">
+                <path d="M16.5,0 C17.3284271,0 18,0.671572875 18,1.5 L18,22.5 C18,23.3284271 17.3284271,24 16.5,24 L1.5,24 C0.671572875,24 0,23.3284271 0,22.5 L0,1.5 C0,0.671572875 0.671572875,0 1.5,0 L16.5,0 Z M16,22 L16,2 L2,2 L2,22 L16,22 Z" id="Path-2"></path>
+                <rect id="Rectangle-path" x="8" y="5" width="5" height="2"></rect>
+                <rect id="Rectangle-path" x="8" y="8" width="5" height="2"></rect>
+                <rect id="Rectangle-path" x="8" y="11" width="5" height="2"></rect>
+                <rect id="Rectangle-path" x="8" y="14" width="5" height="2"></rect>
+                <rect id="Rectangle-path" x="8" y="17" width="5" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="5" width="2" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="8" width="2" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="11" width="2" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="14" width="2" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="17" width="2" height="2"></rect>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/svg/BankAccount32.svg
+++ b/svg/BankAccount32.svg
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="12px" height="16px" viewBox="0 0 12 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-    <title>Icone</title>
+<svg width="32px" height="32px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
+    <title>Icone Copy 2</title>
     <desc>Created with Sketch.</desc>
-    <defs>
-        <path d="M13,0 L3,0 C2.44771525,0 2,0.44771525 2,1 L2,15 C2,15.5522847 2.44771525,16 3,16 L13,16 C13.5522847,16 14,15.5522847 14,15 L14,1 C14,0.44771525 13.5522847,0 13,0 Z M13,15 L3,15 L3,1 L13,1 L13,15 Z M6.5,3 L11,3 L11,4 L6.5,4 L6.5,3 Z M6.5,5 L11,5 L11,6 L6.5,6 L6.5,5 Z M6.5,7 L11,7 L11,8 L6.5,8 L6.5,7 Z M6.5,9 L11,9 L11,10 L6.5,10 L6.5,9 Z M6.5,11 L11,11 L11,12 L6.5,12 L6.5,11 Z M4.5,3 L5.5,3 L5.5,4 L4.5,4 L4.5,3 Z M4.5,5 L5.5,5 L5.5,6 L4.5,6 L4.5,5 Z M4.5,7 L5.5,7 L5.5,8 L4.5,8 L4.5,7 Z M4.5,9 L5.5,9 L5.5,10 L4.5,10 L4.5,9 Z M4.5,11 L5.5,11 L5.5,12 L4.5,12 L4.5,11 Z" id="path-1"></path>
-    </defs>
     <g id="Detalhes-do-recebedor" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Detalhes-do-recebedor---Configuracoes---fechada" transform="translate(-308.000000, -567.000000)">
-            <g id="Conta-bancaria" transform="translate(266.000000, 527.000000)">
-                <g id="Icons/16/Assinaturas" transform="translate(40.000000, 40.000000)">
-                    <mask id="mask-2" fill="white">
-                        <use xlink:href="#path-1"></use>
-                    </mask>
-                    <use id="Shape" fill="#000000" fill-rule="nonzero" xlink:href="#path-1"></use>
-                    <g id="Color/type_default---#757575" mask="url(#mask-2)" fill="#757575" fill-rule="evenodd">
-                        <rect id="Color-shape" x="0" y="0" width="16" height="16"></rect>
-                    </g>
-                </g>
+        <g id="Detalhes-do-recebedor---Configuracoes---fechada" transform="translate(-341.000000, -663.000000)" fill="#757575" fill-rule="nonzero">
+            <g id="Icone-Copy-2" transform="translate(345.000000, 663.000000)">
+                <path d="M22,0 C23.1045695,0 24,0.8954305 24,2 L24,30 C24,31.1045695 23.1045695,32 22,32 L2,32 C0.8954305,32 0,31.1045695 0,30 L0,2 C0,0.8954305 0.8954305,0 2,0 L22,0 Z M22,30 L22,2 L2,2 L2,30 L22,30 Z" id="Path-3"></path>
+                <rect id="Rectangle-path" x="9" y="7" width="9" height="2"></rect>
+                <rect id="Rectangle-path" x="9" y="11" width="9" height="2"></rect>
+                <rect id="Rectangle-path" x="9" y="15" width="9" height="2"></rect>
+                <rect id="Rectangle-path" x="9" y="19" width="9" height="2"></rect>
+                <rect id="Rectangle-path" x="9" y="23" width="9" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="7" width="2" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="11" width="2" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="15" width="2" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="19" width="2" height="2"></rect>
+                <rect id="Rectangle-path" x="5" y="23" width="2" height="2"></rect>
             </g>
         </g>
     </g>


### PR DESCRIPTION
PR aberto para a adição de um ícone que será utilizado na pilot para a tela de Detalhes do Recebedor.
Estou incluindo os dois tamanhos para esse ícone: 24 e 32.