### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emblematic-icons",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A set of pixel-perfect icons tailored for the web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
this PR bumps version to 0.6.1