### PR TITLE
fix: trigger in ci

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -3,7 +3,7 @@ name: publish-npm-package
 on:
   push:
     tags:
-      - /^v([0-9]+).([0-9]+).([0-9]+)$/
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publish:


### PR DESCRIPTION
Nessa tarefa convertemos o arquivo .circleci/config.yml para o github Action agora chamado de publish-npm-package.yml (que está em .github/workflows/publish-npm-package.yml)